### PR TITLE
sorting of components into aplha

### DIFF
--- a/docs/src/components/AppNavigationDrawer.vue
+++ b/docs/src/components/AppNavigationDrawer.vue
@@ -59,7 +59,6 @@ export default {
     // to sort categories into alpha
     getSortCategories() {
       this.$options.categories.forEach((element, index) => {
-        console.log(element);
         if (element.category_name !== 'Getting Started' || index !== 0) {
           this.$options.categories[index].pages.sort((x, y) => (x.page_name > y.page_name ? 1 : y.page_name > x.page_name ? -1 : 0));
         }

--- a/docs/src/components/AppNavigationDrawer.vue
+++ b/docs/src/components/AppNavigationDrawer.vue
@@ -52,9 +52,20 @@ export default {
     };
   },
   created() {
+    this.getSortCategories();
     this.getActiveCategory();
   },
   methods: {
+    // to sort categories into alpha
+    getSortCategories() {
+      this.$options.categories.forEach((element, index) => {
+        console.log(element);
+        if (element.category_name !== 'Getting Started' || index !== 0) {
+          this.$options.categories[index].pages.sort((x, y) => (x.page_name > y.page_name ? 1 : y.page_name > x.page_name ? -1 : 0));
+        }
+      });
+    },
+
     getActiveCategory() {
       for (let category of this.$options.categories) {
         for (let page of category.pages) {


### PR DESCRIPTION
Fixed Sorting of Components Name to alpha in **vue Documentation**

`element.category_name !== 'Getting Started' || index !== 0`
added this is to exclude the Getting Started Accordion because it is the initial process of documentation,
as it contains initial step **`Installation`** which should be in the First place. 
Thus i exclued the **`0 index`**


#16 