### PR TITLE
Align LvColorPicker with other elements in Rating Realtime Customizations

### DIFF
--- a/core/components/color-picker/ColorPicker.vue
+++ b/core/components/color-picker/ColorPicker.vue
@@ -92,10 +92,6 @@ export default {
 </script>
 
 <style>
-.lv-colorpicker-wrapper {
-  display: inline-block;
-  vertical-align: middle;
-}
 
 .lv-colorpicker__colorblock-wrap {
   position: relative;

--- a/examples/colorpicker/ColorpickerDemo2.vue
+++ b/examples/colorpicker/ColorpickerDemo2.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="lv-colorpicker-wrapper">
     <h6>Chosen color: {{ hexCode }} : <LvColorpicker v-model="hexCode" withoutInput /></h6>
   </div>
 </template>
@@ -18,4 +18,11 @@ export default {
 };
 </script>
 
-<style></style>
+<style>
+
+.lv-colorpicker-wrapper {
+  display: inline-block;
+  vertical-align: middle;
+}
+
+</style>


### PR DESCRIPTION
PR aligns the color picker in `vue-components/rating` without affecting `vue-components/color-picker/#without-input` as seen in the following screenshots.

Fixes #138 

## Screenshots
![Screen Shot 2022-10-01 at 6 52 42 PM](https://user-images.githubusercontent.com/20748598/193432306-a87149bc-e7a9-4fed-87df-663584f87354.png)

![Screen Shot 2022-10-01 at 6 52 34 PM](https://user-images.githubusercontent.com/20748598/193432307-783fb2a0-3845-4677-b18d-f0e32b9287fd.png)
