### PR TITLE
Close dropdown on back event

### DIFF
--- a/core/components/dropdown/Dropdown.vue
+++ b/core/components/dropdown/Dropdown.vue
@@ -32,14 +32,14 @@
 
 <script>
 import { ConnectedOverlayScrollHandler, ObjectUtils, DomHandler } from 'lightvue/utils';
-import { trueValueMixin, optionsMixin } from 'lightvue/mixins';
+import { trueValueMixin, optionsMixin, preventBrowserBackMixin } from 'lightvue/mixins';
 import Ripple from 'lightvue/ripple';
 import LvInput from 'lightvue/input';
 
 export default {
   name: 'LvDropdown',
   inheritAttrs: false,
-  mixins: [trueValueMixin, optionsMixin],
+  mixins: [trueValueMixin, optionsMixin, preventBrowserBackMixin],
   emits: ['before-show', 'before-hide', 'show', 'hide', 'change', 'filter'],
   components: {
     LvInput,
@@ -459,6 +459,10 @@ export default {
     //     this.overlay = el;
     //     return 'overlayRef';
     // }
+    handleOnBrowserBack() {
+      // Called from Mixin
+      this.hide();
+    },
   },
   computed: {
     modelValue() {


### PR DESCRIPTION
## Description
I imported the "preventBrowserBackMixin", added it into the mixins and added the "handleOnBrowserBack" method that calls the "hide" method on this.

---
## Issue Ticket Number
Fixes #24

---
## Type of change
<!-- Please select all options that are applicable. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

---
# Checklist:
- [x] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/lightvue/lightvue/pulls) for the same update/change?
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes needed to the documentation
